### PR TITLE
Added actions from OpenVR to control video playback.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ docs/
 .vs/
 **/*.swp
 **/*.mp4
+include/shadersource.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ set(CMAKE_CXX_STANDARD 11)
 
 option(BUILD_DOCUMENTATION "Bulid the documentation with Doxygen" OFF)
 
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 # Pull down submodules
 find_package(Git QUIET)
 if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
@@ -129,18 +132,25 @@ target_compile_definitions(stereo INTERFACE LOG_SOURCE_MODULE="stereo")
 # Add example executable directories
 add_subdirectory(example)
 target_compile_definitions(stereo PRIVATE LOG_SOURCE_MODULE="stereo-world")
-set_target_properties(stereo-world PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-)
 
 if(WIN32)
     set(OPENVR_DLL "${PROJECT_SOURCE_DIR}/libs/openvr/bin/win64/openvr_api.dll")
-	message("Copying ${OPENVR_DLL} to ${CMAKE_CURRENT_BINARY_DIR}")
+	message("Copying ${OPENVR_DLL} to ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
     file(
         COPY ${OPENVR_DLL}
-        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+        DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     )
 endif()
+
+file (
+  COPY "${PROJECT_SOURCE_DIR}/actions.json"
+  DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+)
+
+file (
+  COPY "${PROJECT_SOURCE_DIR}/gamepad_bindings.json"
+  DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+)
 
 # Enable all warnings and treat them as errors
 if(MSVC)
@@ -152,8 +162,3 @@ endif()
 target_compile_options(stereo ${WARNING_FLAGS})
 target_compile_options(stereo-static ${WARNING_FLAGS})
 target_compile_options(stereo-world ${WARNING_FLAGS})
-
-file(
-    COPY ${OPENVR_DLL}
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
-)

--- a/actions.json
+++ b/actions.json
@@ -1,0 +1,40 @@
+{
+   "action_sets" : [
+      {
+         "name" : "/actions/playback",
+         "usage" : "single"
+      }
+   ],
+   "actions" : [
+      {
+         "name" : "/actions/playback/in/play_pause",
+         "requirement" : "suggested",
+         "type" : "boolean"
+      },
+      {
+         "name" : "/actions/playback/in/fastforward",
+         "requirement" : "suggested",
+         "type" : "boolean"
+      },
+      {
+         "name" : "/actions/playback/in/stop",
+         "requirement" : "suggested",
+         "type" : "boolean"
+      }
+   ],
+   "default_bindings" : [
+      {
+         "binding_url" : "gamepad_bindings.json",
+         "controller_type" : "gamepad"
+      }
+   ],
+   "localization" : [
+      {
+         "/actions/playback" : "Playback",
+         "/actions/playback/in/fastforward" : "Fast forward",
+         "/actions/playback/in/play_pause" : "Play/Pause",
+         "/actions/playback/in/stop" : "Stop",
+         "language_tag" : "en_us"
+      }
+   ]
+}

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -21,6 +21,16 @@ set(ICONIC_LIBRARIES
 )
 set(ICONIC_INCLUDE_DIR "$ENV{ICONICPATH}/IconicGpu/include")
 
+file(GLOB ICONIC_DLL_LIST "$ENV{ICONICPATH}/IconicGpu/x64/Release/*.dll")
+message("DLLS: ${ICONIC_DLL_LIST}")
+foreach(ICONIC_DLL ${ICONIC_DLL_LIST})
+    message("DLL: ${ICONIC_DLL}")
+    file(
+        COPY "${ICONIC_DLL}"
+        DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    )
+endforeach(ICONIC_DLL)
+
 find_package(Boost REQUIRED)
 find_package(Eigen3 REQUIRED)
 

--- a/example/src/main.cpp
+++ b/example/src/main.cpp
@@ -91,11 +91,12 @@ public:
         auto elapsed_seconds = 1e-9 * (double)elapsed_nanos;
 
         bool bFramesDecoded = false;
-        if (elapsed_seconds > seconds_per_frame) {
+
+        bool should_render = (this->playback == Playback::PLAY && elapsed_seconds > seconds_per_frame) 
+            || this->playback == Playback::FFW;
+        if (should_render) {
             this->previous_frame_time = now;
-            if (this->playback == Playback::PLAY) {
-                decoder->renderVideoFrame(this->canvas, true, true, bFramesDecoded);
-            }
+            decoder->renderVideoFrame(this->canvas, true, true, bFramesDecoded);
         }
 
         Frame frame;

--- a/gamepad_bindings.json
+++ b/gamepad_bindings.json
@@ -1,0 +1,44 @@
+{
+   "action_manifest_version" : 0,
+   "alias_info" : {},
+   "app_key" : "system.generated.stereo-world.exe",
+   "bindings" : {
+      "/actions/playback" : {
+         "sources" : [
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/playback/in/play_pause"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/gamepad/input/a"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/playback/in/fastforward"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/gamepad/input/dpad_right"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/playback/in/stop"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/gamepad/input/b"
+            }
+         ]
+      }
+   },
+   "category" : "steamvr_input",
+   "controller_type" : "gamepad",
+   "description" : "",
+   "name" : "default_gamepad_actions",
+   "options" : {},
+   "simulated_actions" : []
+}


### PR DESCRIPTION
We specify an "[Action Manifest](https://github.com/ValveSoftware/openvr/wiki/Action-manifest)" (`actions.json`) which registers actions that may be bound to controller buttons by the user.

In `stereo.cpp` we handle the inputs in the main loop and change the playback in the video decoder.

Now also copies the DLLs from I-CONIC's proprietary library when building the example executable.